### PR TITLE
Add prototype Pico_Test target

### DIFF
--- a/redo/targets/gpr/pico_test.gpr
+++ b/redo/targets/gpr/pico_test.gpr
@@ -1,0 +1,29 @@
+with "pico_bsp.gpr";
+
+project pico_test extends all "a_bareboard_development.gpr" is
+
+   -----------------------------------------------
+   -- These lines of code must be included at the
+   -- top of every Adamant based .gpr file. They
+   -- are used to connect the Adamant build system
+   -- to GPRBuild.
+   -----------------------------------------------
+   for Source_Dirs use a_adamant.SOURCE_DIRS;
+   for Excluded_Source_Files use a_adamant.EXCLUDED_SOURCE_FILES;
+   for Object_Dir use a_adamant.OBJECT_DIR;
+   for Exec_Dir use a_adamant.EXEC_DIR;
+
+   for Target use "arm-eabi";
+   for Runtime ("Ada") use "embedded-rpi-pico";
+   for Languages use ("Ada", "C", "ASM_CPP");
+   for Main use ("test_pico.adb");
+
+   package Binder is
+      for Switches ("Ada") use a_bareboard_base.Binder'Switches ("Ada") & ("-E");
+   end Binder;
+
+   package Linker is
+      for Switches ("Ada") use a_bareboard_base.Linker'Switches ("Ada");
+   end Linker;
+
+end pico_test;

--- a/redo/targets/pico_test.py
+++ b/redo/targets/pico_test.py
@@ -1,0 +1,17 @@
+from targets.pico import Pico_Base
+import os.path
+
+
+class Pico_Test(Pico_Base):
+    """Test target for Pico that attempts to link AUnit."""
+    def description(self):
+        return ("Same as Pico_Development except it links with AUnit for unit tests.")
+
+    def path_files(self):
+        return list(set(super(Pico_Test, self).path_files() + ["Pico"]))
+
+    def gpr_project_file(self):
+        return os.path.join(
+            os.environ["EXAMPLE_DIR"],
+            "redo" + os.sep + "targets" + os.sep + "gpr" + os.sep + "pico_test.gpr",
+        )


### PR DESCRIPTION
## Summary

Add the prototype `Pico_Test` target files used to explore embedded Pico compilation of the `command_router` test stack.

## What changed

- add `redo/targets/pico_test.py`
- add `redo/targets/gpr/pico_test.gpr`

## Notes

This is a companion PR to the `adamant` prototype PR. On its own, it only adds the prototype target definition used during the embedded build experiments.
